### PR TITLE
Update plugin client for PeerTube v7 div classes

### DIFF
--- a/client/common-client-plugin.js
+++ b/client/common-client-plugin.js
@@ -10,14 +10,14 @@ function register ({ registerHook, peertubeHelpers }) {
         panel.innerHTML = html;
       }
       setInterval(async function(){
-        if (document.querySelector('.top-menu .custom-links') === null && c['custom_links_markdown']) {
-          const topMenu = document.querySelector('.top-menu');
-          if (topMenu) {
-            topMenu.appendChild(panel);
+        if (document.querySelector('.main-menu .custom-links') === null && c['custom_links_markdown']) {
+          const mainMenu = document.querySelector('.main-menu');
+          if (mainMenu) {
+            mainMenu.appendChild(panel);
           }
         }
-        if (document.querySelector('.menu-wrapper .custom-links') === null && c['custom_links_markdown']) {
-          const mainContent = document.querySelector('.menu-wrapper');
+        if (document.querySelector('.main-menu-wrapper .custom-links') === null && c['custom_links_markdown']) {
+          const mainContent = document.querySelector('.main-menu-wrapper');
           if (mainContent) {
             panel.classList.add('section')
             mainContent.appendChild(panel)


### PR DESCRIPTION
PeerTube v7 introduces a few different divs, breaking the existing menu plugin. I've updated the divs to match what's in PeerTube's current interface, in the hopes of maintaining compatibility.

This will break the plugin for anyone on a version lower than PeerTube v7. I don't know if we want to incorporate special handling to consider earlier versions, or simply rip off the band-aid.